### PR TITLE
repo was renamed from mastodon-backup to mastodon-archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ There's one thing you need to remember, though: the media directory
 contains all the media from your statuses, and all the media from your
 favourites. There is no particular reason why the media files from
 both sources need to be in the same directory, see
-[issue #11](https://github.com/kensanata/mastodon-backup/issues/11).
+[issue #11](https://github.com/kensanata/mastodon-archive/issues/11).
 
 # Generating a text file
 
@@ -478,7 +478,7 @@ If you use `--older-than 0`, then *all* your toots will be deleted, or
 will be dismissed.
 
 ```text
-~/src/mastodon-backup $ mastodon-archive expire --older-than 0 kensanata@social.nasqueron.org
+~/src/mastodon-archive $ mastodon-archive expire --older-than 0 kensanata@social.nasqueron.org
 This is a dry run and nothing will be expired.
 Instead, we'll just list what would have happened.
 Use --confirmed to actually do it.

--- a/contrib/debinstall.sh
+++ b/contrib/debinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# install mastodon-backup via Debian packages instead of PyPi dependencies
+# install mastodon-archive via Debian packages instead of PyPi dependencies
 # © 2022 Izzy <izzysoft AT qumran DOT org>; GPL-3.0-or-later
 
 # -----------------------------------------------------------------------------

--- a/mastodon_archive/media.py
+++ b/mastodon_archive/media.py
@@ -74,7 +74,7 @@ def media(args):
                 req = urllib.request.Request(
                     url, data=None,
                     headers={'User-Agent': 'Mastodon-Archive/1.3 '
-                             '(+https://github.com/kensanata/mastodon-backup#mastodon-archive)'})
+                             '(+https://github.com/kensanata/mastodon-archive#mastodon-archive)'})
                 try:
                   with urllib.request.urlopen(req) as response, open(file_name, 'wb') as fp:
                     data = response.read()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Alex Schroeder",
     author_email="alex@gnu.org",
-    url='https://github.com/kensanata/mastodon-backup#mastodon-archive',
+    url='https://github.com/kensanata/mastodon-archive#mastodon-archive',
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
so let's adjust all references.

@kensanata shall I remove/fix `debinstall.sh` as well with the packages about to be released, and push that to this PR? Once the packages are in a/my repo, there's nothing left in the script that's not covered elsewhere.We have `contrib/upgrade_python-mastodon.sh` to make sure the latest `Mastodon.py` is installed, and everything else should rather go into the install instructions in the readme (pointing to the instructions on [how to add my RPM](https://apt.izzysoft.de/redhat/) or [my DEB](https://apt.izzysoft.de/ubuntu/dists/generic/) repo to the source lists, plus to run `apt install mastodon-archive` or `yum install mastodon-archive` after having refreshed the indexes).