### PR TITLE
Add global --quiet option and media --suppress-errors option

### DIFF
--- a/mastodon_archive/__init__.py
+++ b/mastodon_archive/__init__.py
@@ -39,6 +39,9 @@ def main():
         use 'all' instead of your account and the commands will be run
         once for every archive in the directory.""")
 
+    parser.add_argument("--quiet", "-q", action='store_true', default=False,
+                        help='do not output normal status messages')
+
     subparsers = parser.add_subparsers()
 
 
@@ -103,6 +106,9 @@ def main():
     parser_content.add_argument("--pace", dest='pace', action='store_const',
                                 const=True, default=False,
                                 help='avoid timeouts and pace requests')
+    parser_content.add_argument("--suppress-errors", action='store_true',
+                                default=False, help="don't print messages "
+                                "about media that can't be downloaded")
     parser_content.set_defaults(command=media.media)
 
 

--- a/mastodon_archive/context.py
+++ b/mastodon_archive/context.py
@@ -42,7 +42,8 @@ def context(args):
                        "bookmarks",
                        "mentions"]:
         statuses = data[collection];
-        print("Indexing %d %s..." % (len(statuses), collection))
+        if not args.quiet:
+            print("Indexing %d %s..." % (len(statuses), collection))
         for status in statuses:
 
             if status["reblog"] is not None:

--- a/mastodon_archive/core.py
+++ b/mastodon_archive/core.py
@@ -269,7 +269,7 @@ def load(file_name, required=False, quiet=False, combine=False):
 
     return None
 
-def save(file_name, data):
+def save(file_name, data, quiet=False):
     """
     Save the JSON data in a file. If the file exists, rename it,
     just in case.
@@ -281,7 +281,8 @@ def save(file_name, data):
 
     if os.path.isfile(file_name):
         backup_file = file_name + '~'
-        print("Backing up", file_name, "to", backup_file)
+        if not quiet:
+            print("Backing up", file_name, "to", backup_file)
         if os.path.isfile(backup_file):
             ans = ""
             while ans.lower() not in ("y", "n", "yes", "no"):

--- a/mastodon_archive/expire.py
+++ b/mastodon_archive/expire.py
@@ -72,7 +72,7 @@ def expire(args):
     (username, domain) = args.user.split('@')
 
     status_file = domain + '.user.' + username + '.json'
-    data = core.load(status_file, required = True)
+    data = core.load(status_file, required = True, quiet = True)
 
     if confirmed:
         mastodon = core.readwrite(args)
@@ -135,29 +135,35 @@ def expire(args):
             if error:
                 print(error, file=sys.stderr)
 
-            core.save(status_file, data)
+            core.save(status_file, data, quiet=args.quiet)
 
         elif n_statuses > 0:
 
             for status in statuses:
                 if collection == 'statuses':
-                    print("Delete: " + text(status))
+                    if not args.quiet:
+                        print("Delete: " + text(status))
                 elif collection == 'favourites':
-                    print("Unfavour: " + text(status))
+                    if not args.quiet:
+                        print("Unfavour: " + text(status))
 
     if collection == "mentions":
 
         if delete_others:
-            print('Dismissing mentions and other notifications')
+            if not args.quiet:
+                print('Dismissing mentions and other notifications')
         else:
-            print('Dismissing mentions')
+            if not args.quiet:
+                print('Dismissing mentions')
 
-        progress = core.progress_bar()
+        if not args.quiet:
+            progress = core.progress_bar()
 
         # only consider statuses with an id (no idea what the others are)
         statuses = list(filter(lambda x: "id" in x, data[collection]))
-        n_statuses = len(statuses)
-        print("Mentions already archived: " + str(n_statuses))
+        if not args.quiet:
+            n_statuses = len(statuses)
+            print("Mentions already archived: " + str(n_statuses))
 
         # create a dictionary for fast lookup of archived statuses that mention us
         ids = { x["id"]: True for x in statuses }
@@ -178,7 +184,8 @@ def expire(args):
         total = 0
         dismissed = 0
         while (notifications):
-            progress()
+            if not args.quiet:
+                progress()
             total += len(notifications)
             for notification in matches(notifications):
                 if confirmed:
@@ -211,4 +218,5 @@ def expire(args):
         if error:
             print(error, file=sys.stderr)
 
-        print(f"Dismissed {dismissed} of {total} notifications")
+        if not args.quiet:
+            print(f"Dismissed {dismissed} of {total} notifications")

--- a/mastodon_archive/fix.py
+++ b/mastodon_archive/fix.py
@@ -32,7 +32,8 @@ def fix_boosts(args):
     (username, domain) = core.parse(args.user)
 
     status_file = domain + '.user.' + username + '.json'
-    data = core.load(status_file, required=True, combine=args.combine)
+    data = core.load(status_file, required=True, combine=args.combine,
+                     quiet=args.quiet)
     n = 0
 
     for status in data["statuses"]:
@@ -46,12 +47,14 @@ def fix_boosts(args):
 
     if confirmed and n > 0:
 
-        print("Saving updated data to", status_file)
-        core.save(status_file, data)
+        if not args.quiet:
+            print("Saving updated data to", status_file)
+        core.save(status_file, data, quiet=args.quiet)
 
     elif confirmed:
 
-        print("No boosted statuses were undeleted")
+        if not args.quiet:
+            print("No boosted statuses were undeleted")
 
     else:
 

--- a/mastodon_archive/followers.py
+++ b/mastodon_archive/followers.py
@@ -54,12 +54,14 @@ def followers(args):
         sys.exit(error)
 
     if args.all:
-        print("Considering the entire archive")
+        if not args.quiet:
+            print("Considering the entire archive")
         mentions = data["mentions"]
     else:
-        print("Considering the last "
-              + str(args.weeks)
-              + " weeks")
+        if not args.quiet:
+            print("Considering the last "
+                  + str(args.weeks)
+                  + " weeks")
         mentions = core.keep(data["mentions"], args.weeks)
 
     whitelist = core.whitelist(domain, username)
@@ -68,10 +70,12 @@ def followers(args):
         mastodon = core.readwrite(args)
         accounts = find_lurkers(data["followers"], whitelist, data["mentions"])
 
-        bar = Bar('Blocking', max = len(accounts))
+        if not args.quiet:
+            bar = Bar('Blocking', max = len(accounts))
 
         for account in accounts:
-            bar.next()
+            if not args.quiet:
+                bar.next()
             try:
                 mastodon.account_block(account["id"])
             except Exception as e:
@@ -84,7 +88,8 @@ def followers(args):
                 else:
                     print(e, file=sys.stderr)
 
-        bar.finish()
+        if not args.quiet:
+            bar.finish()
 
     else:
         accounts = find_lurkers(data["followers"], whitelist, data["mentions"])

--- a/mastodon_archive/following.py
+++ b/mastodon_archive/following.py
@@ -54,12 +54,14 @@ def following(args):
         sys.exit(error)
 
     if args.all:
-        print("Considering the entire archive")
+        if not args.quiet:
+            print("Considering the entire archive")
         mentions = data["mentions"]
     else:
-        print("Considering the last "
-              + str(args.weeks)
-              + " weeks")
+        if not args.quiet:
+            print("Considering the last "
+                  + str(args.weeks)
+                  + " weeks")
         mentions = core.keep(data["mentions"], args.weeks)
 
     whitelist = core.whitelist(domain, username)
@@ -68,10 +70,12 @@ def following(args):
         mastodon = core.readwrite(args)
         accounts = find_lurkers(data["following"], whitelist, data["mentions"])
 
-        bar = Bar('Unfollowing', max = len(accounts))
+        if not args.quiet:
+            bar = Bar('Unfollowing', max = len(accounts))
 
         for account in accounts:
-            bar.next()
+            if not args.quiet:
+                bar.next()
             try:
                 mastodon.account_unfollow(account["id"])
             except Exception as e:
@@ -84,7 +88,8 @@ def following(args):
                 else:
                     print(e, file=sys.stderr)
 
-        bar.finish()
+        if not args.quiet:
+            bar.finish()
 
     else:
         accounts = find_lurkers(data["following"], whitelist, data["mentions"])

--- a/mastodon_archive/html.py
+++ b/mastodon_archive/html.py
@@ -292,7 +292,8 @@ def html(args):
     status_file = domain + '.user.' + username + '.json'
     media_dir = domain + '.user.' + username
     base_url = 'https://' + domain
-    data = core.load(status_file, required=True, combine=combine)
+    data = core.load(status_file, required=True, combine=combine,
+                     quiet=args.quiet)
     user = data["account"]
     statuses = data[collection]
 
@@ -324,7 +325,8 @@ def html(args):
 
             with open(file_name, mode = 'w', encoding = 'utf-8') as fp:
 
-                print("Writing %s" % file_name)
+                if not args.quiet:
+                    print("Writing %s" % file_name)
 
                 html = header_template % (
                     user["display_name"],

--- a/mastodon_archive/login.py
+++ b/mastodon_archive/login.py
@@ -25,7 +25,8 @@ def login(args):
 
     mastodon = core.login(args)
 
-    print("Get user info")
+    if not args.quiet:
+        print("Get user info")
 
     try:
         user = mastodon.account_verify_credentials()

--- a/mastodon_archive/media.py
+++ b/mastodon_archive/media.py
@@ -56,15 +56,18 @@ def media(args):
     for picture in ["avatar", "header"]:
         urls.append(data["account"][picture])
 
-    print("%d urls in your backup (%d are previews)" % (len(urls), preview_urls_count))
+    if not args.quiet:
+        print("%d urls in your backup (%d are previews)" % (len(urls), preview_urls_count))
 
-    bar = Bar('Downloading', max = len(urls))
+    if not args.quiet:
+        bar = Bar('Downloading', max = len(urls))
 
     errors = 0
 
     # start downloading the missing files from the back
     for url in reversed(urls):
-        bar.next()
+        if not args.quiet:
+            bar.next()
         path = urlparse(url).path
         file_name = media_dir + path
         if not os.path.isfile(file_name):
@@ -80,16 +83,19 @@ def media(args):
                     data = response.read()
                     fp.write(data)
                 except HTTPError as he:
-                  print("\nFailed to open " + url + " during a media request.")
+                  if not args.suppress_errors:
+                      print("\nFailed to open " + url + " during a media request.")
                 except URLError as ue:
-                  print("\nFailed to open " + url + " during a media request.")
+                  if not args.suppress_errors:
+                      print("\nFailed to open " + url + " during a media request.")
             except OSError as e:
                 print("\n" + e.msg + ": " + url, file=sys.stderr)
                 errors += 1
             if pace:
                 time.sleep(1)
 
-    bar.finish()
+    if not args.quiet:
+        bar.finish()
 
     if errors > 0:
         print("%d downloads failed" % errors)

--- a/mastodon_archive/meow.py
+++ b/mastodon_archive/meow.py
@@ -68,8 +68,9 @@ def meow(args):
 
     bar = None
     if len(media_files) > 0:
-        bar = Bar("Exporting files", max = len(media_files) + 1)
-        file_cb = lambda *args: bar.next()
+        if not args.quiet:
+            bar = Bar("Exporting files", max = len(media_files) + 1)
+            file_cb = lambda *args: bar.next()
 
     serve(server_port, meow_origin, data, media_dir, media_files, file_cb)
 

--- a/mastodon_archive/mutuals.py
+++ b/mastodon_archive/mutuals.py
@@ -37,7 +37,8 @@ def mutuals(args):
 
     mastodon = core.login(args)
 
-    print("Get user info")
+    if not args.quiet:
+        print("Get user info")
 
     try:
         user = mastodon.account_verify_credentials()

--- a/mastodon_archive/replies.py
+++ b/mastodon_archive/replies.py
@@ -26,11 +26,12 @@ def replies(args):
     (username, domain) = core.parse(args.user)
 
     status_file = domain + '.user.' + username + '.json'
-    data = core.load(status_file, required = True)
+    data = core.load(status_file, required = True, quiet = args.quiet)
 
     mastodon = core.login(args)
 
-    print("Get user info")
+    if not args.quiet:
+        print("Get user info")
 
     try:
         user = mastodon.account_verify_credentials()
@@ -57,10 +58,12 @@ def replies(args):
                        "mentions",
                        "replies"]:
         if collection not in data:
-            print("No %s in this archive..." % collection)
+            if not args.quiet:
+                print("No %s in this archive..." % collection)
         else:
             statuses = data[collection];
-            print("Indexing %d %s..." % (len(statuses), collection))
+            if not args.quiet:
+                print("Indexing %d %s..." % (len(statuses), collection))
             for status in statuses:
 
                 if status["reblog"] is not None:
@@ -71,19 +74,23 @@ def replies(args):
                     pass
                 else:
                     index[status["id"]] = 1
-    print("Indexed %d statuses..." % (len(index)))
+    if not args.quiet:
+        print("Indexed %d statuses..." % (len(index)))
 
-    print("Counting missing replies...")
+    if not args.quiet:
+        print("Counting missing replies...")
     for status in data["statuses"]:
         # skip boosts
         if status["reblog"] is None and status["in_reply_to_id"] is not None:
             if status["in_reply_to_id"] not in index:
                 missing.append(status["in_reply_to_id"])
-    print("Missing %d originals..." % (len(missing)))
+    if not args.quiet:
+        print("Missing %d originals..." % (len(missing)))
 
     if len(missing) > 300:
-        print("Given the typical rate limit of 300 requests per 5 minutes, "
-              "this will take about %d minutes" % (len(missing) // 300 * 5))
+        if not args.quiet:
+            print("Given the typical rate limit of 300 requests per 5 minutes, "
+                  "this will take about %d minutes" % (len(missing) // 300 * 5))
 
     if len(missing) > 0:
         if not "replies" in data:
@@ -91,7 +98,8 @@ def replies(args):
         else:
             replies = data["replies"]
 
-        bar = Bar('Fetching', max = len(missing))
+        if not args.quiet:
+            bar = Bar('Fetching', max = len(missing))
 
         for id in missing:
             try:
@@ -103,9 +111,11 @@ def replies(args):
                 else:
                     print(e, file=sys.stderr)
 
-            bar.next()
+            if not args.quiet:
+                bar.next()
 
-        bar.finish()
+        if not args.quiet:
+            bar.finish()
 
         data["replies"] = replies
-        core.save(status_file, data)
+        core.save(status_file, data, quiet=args.quiet)

--- a/mastodon_archive/split.py
+++ b/mastodon_archive/split.py
@@ -35,7 +35,7 @@ def split(args):
     (username, domain) = args.user.split('@')
 
     status_file = domain + '.user.' + username + '.json'
-    data = core.load(status_file, required = True)
+    data = core.load(status_file, required = True, quiet = args.quiet)
     older_data = {}
 
     n = 0
@@ -50,7 +50,8 @@ def split(args):
     delta = timedelta(weeks = args.weeks)
     cutoff = datetime.today() - delta
 
-    print("Older than " + str(cutoff))
+    if not args.quiet:
+        print("Older than " + str(cutoff))
 
     n_statuses = 0
 
@@ -69,19 +70,23 @@ def split(args):
         older_data[collection] = older_statuses
 
         moved = len(older_statuses)
-        print(collection + ": " + str(moved))
+        if not args.quiet:
+            print(collection + ": " + str(moved))
         n_statuses += moved
 
     if confirmed and n_statuses > 0:
 
-        print("Saving " + status_file)
-        core.save(status_file, data)
-        print("Saving " + older_status_file)
-        core.save(older_status_file, older_data)
+        if not args.quiet:
+            print("Saving " + status_file)
+        core.save(status_file, data, quiet=args.quiet)
+        if not args.quiet:
+            print("Saving " + older_status_file)
+        core.save(older_status_file, older_data, quiet=args.quiet)
 
     elif confirmed:
 
-        print("No older statuses to move")
+        if not args.quiet:
+            print("No older statuses to move")
 
     else:
 


### PR DESCRIPTION
Add a global `--quiet` option which tells the script not to generate any non-error output.

Add a `--suppress-errors` option to the `media` subcommand which tells the script not to print errors about nonexistent media downloads.

These options are useful, e.g., when you want to periodically archive everything from a cron job but you don't want to receive emails from cron unless something goes wrong.