### PR TITLE
Allow media images to be shown instead of squished down to 110 px.

### DIFF
--- a/mastodon_archive/html.py
+++ b/mastodon_archive/html.py
@@ -115,7 +115,6 @@ a:hover {
 .media {
         margin-top: 8px;
         margin-bottom: 8px;
-        height: 110px;
         overflow: hidden;
 }
 .media a {
@@ -131,11 +130,10 @@ a:hover {
         max-height: 50%%;
         display: block;
 }
-/* http://jonrohan.codes/fieldnotes/vertically-center-clipped-image/ */
+
 .media img {
-        position: relative;
-        top: 50%%;
-        transform: translateY(-50%%);
+        max-width: 100%%;
+        height: auto;
 }
 nav a, .content a {
         color: #d9e1e8;


### PR DESCRIPTION
At least with my archives, the images are limited to 110px tall - kind of weird. This allows them to take up the column width. 

There are still issues with the code failing to recognize when the media type is video, and giving it an img tag. That's beyond my paygrade sadly.