### PR TITLE
Revert use of poster. Return to loading metadata for videos

### DIFF
--- a/mastodon_archive/html.py
+++ b/mastodon_archive/html.py
@@ -220,7 +220,7 @@ image_template = '''\
 '''
 
 video_template = '''\
-<video controls preload="none" src="%s" poster="%s"><a href="%s"><img src="%s"/></a></video>
+<video controls preload="metadata" src="%s" ><a href="%s"><img src="%s"/></a></video>
 '''
 
 wrapper_template = '''\
@@ -269,7 +269,6 @@ def write_status(fp, media_dir, status):
             if attachment["type"] == "video" and src:
                 previews.append(video_template % (
                     src, # video
-                    file_url(media_dir, attachment["preview_url"]), # poster image
                     file_url(media_dir, attachment["remote_url"]), # remote link
                     file_url(media_dir, attachment["preview_url"]))) # image for remote link
             elif attachment["type"] == "image":

--- a/mastodon_archive/html.py
+++ b/mastodon_archive/html.py
@@ -143,6 +143,7 @@ nav a:visited, .content a:visited {
 nav {
         padding: 10px 0;
         border-top: 1px solid #393f4f;
+        height: 1em;
 }
 footer nav {
         padding-bottom: 0;
@@ -184,11 +185,11 @@ nav_template = '''\
 '''
 
 previous_template = '''\
-<a class="previous" href="%s">Previous</a>
+<a class="previous" href="%s">Later</a>
 '''
 
 next_template = '''\
-<a class="next" href="%s">Next</a>
+<a class="next" style="float:right;" href="%s">Earlier</a>
 '''
 
 boost_template = '''\


### PR DESCRIPTION
This works fine when max toots per page is around 25, as long as the viewer has a decent connection.

