### PR TITLE
Not all statuses returned by the server have the 'reactions' key

### DIFF
--- a/mastodon_archive/allowlist.py
+++ b/mastodon_archive/allowlist.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (C) 2018  Alex Schroeder <alex@gnu.org>
+
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+from . import core
+
+def print_allowlist(args):
+
+    (username, domain) = core.parse(args.user)
+
+    allowlist = core.allowlist(domain, username)
+
+    for account in allowlist:
+        print(account)

--- a/mastodon_archive/media.py
+++ b/mastodon_archive/media.py
@@ -44,7 +44,7 @@ def media(args):
         attachments = status["media_attachments"]
         account = status["account"]
         emojis = status["emojis"]
-        reactions = status["reactions"]
+        reactions = status.get("reactions", [])
         card = status["card"]
         if status["reblog"] is not None:
             attachments = status["reblog"]["media_attachments"]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "console_scripts": ["mastodon-archive=mastodon_archive:main"]
     },
     install_requires=[
-        "mastodon.py",
+        "Mastodon.py@https://github.com/jikamens/Mastodon.py/archive/refs/heads/master.zip",
         "progress",
         "html2text",
     ],


### PR DESCRIPTION
Fix this crash:

```
  File "/usr/local/pipx/venvs/mastodon-archive/lib/python3.13/site-packages/mastodon_archive/media.py", line 47, in media
    reactions = status["reactions"]
                ~~~~~~^^^^^^^^^^^^^
KeyError: 'reactions'
```